### PR TITLE
Added maxMonth for ReservationCalendar

### DIFF
--- a/src/components/ReservationCalendar.tsx
+++ b/src/components/ReservationCalendar.tsx
@@ -206,10 +206,10 @@ class ReservationCalendar extends Component<Props, CalendarState> {
           this.fetchDataForMonth(calendarDateObject);
         }}
         onPressArrowLeft={
-          (substractMonth) => this.monthCanBeSubstracted() === true ? substractMonth() : undefined
+          (substractMonth) => this.monthCanBeSubstracted() ? substractMonth() : undefined
         }
         onPressArrowRight={
-          (addMonth) => this.monthCanBeAdded() === true ? addMonth() : undefined
+          (addMonth) => this.monthCanBeAdded() ? addMonth() : undefined
         }
         theme={{
           'textDayFontFamily': 'Exo2-bold',

--- a/src/components/ReservationCalendar.tsx
+++ b/src/components/ReservationCalendar.tsx
@@ -24,18 +24,25 @@ interface CalendarState {
   calendarData: CalendarEntry[];
   currentMonth: number;
   currentYear: number;
-  maxMonth: number;
+  maxDate: Date;
 }
 
 class ReservationCalendar extends Component<Props, CalendarState> {
   constructor(props: Props) {
     super(props);
-    const date = new Date();
+    const currentDate = new Date();
+    const initMaxDate = new Date();
+    const maxDate = new Date(initMaxDate.setMonth(initMaxDate.getMonth()+11));
+    // Adding (full) months to dates have different outcomes based on which is
+    // the day parameter of the Date object. The day is set to middle of the
+    // month to eliminate that. The date does not matter because we are only
+    // interested about the month.
+    maxDate.setDate(15);
     this.state = {
       calendarData: [],
-      currentMonth: date.getMonth()+1,
-      currentYear: date.getFullYear(),
-      maxMonth: new Date(date.setMonth(date.getMonth()+6)).getMonth()+1
+      currentMonth: currentDate.getMonth()+1,
+      currentYear: currentDate.getFullYear(),
+      maxDate: maxDate
     };
     this.fetchDataForMonth = this.fetchDataForMonth.bind(this);
     this.toggleSelectedDay = this.toggleSelectedDay.bind(this);
@@ -106,7 +113,9 @@ class ReservationCalendar extends Component<Props, CalendarState> {
   }
 
   monthCanBeAdded() {
-    if (this.state.currentMonth >= this.state.maxMonth) {
+    // Calendar range is set on (current month + 11), meaning that every month is
+    // represented only once for user
+    if (this.state.currentMonth === this.state.maxDate.getMonth()+1) {
       return false;
     }
     return true;
@@ -114,6 +123,9 @@ class ReservationCalendar extends Component<Props, CalendarState> {
 
   monthCanBeSubstracted() {
     const currentDate = new Date();
+    // Calendar range is set in a way that user can't navigate to the same month next year.
+    // So the month can't be same in other situations than when calendar state is on the
+    // current month.
     if (this.state.currentMonth === currentDate.getMonth()+1) {
       return false;
     }

--- a/src/components/ReservationCalendar.tsx
+++ b/src/components/ReservationCalendar.tsx
@@ -24,6 +24,7 @@ interface CalendarState {
   calendarData: CalendarEntry[];
   currentMonth: number;
   currentYear: number;
+  maxMonth: number;
 }
 
 class ReservationCalendar extends Component<Props, CalendarState> {
@@ -33,10 +34,13 @@ class ReservationCalendar extends Component<Props, CalendarState> {
     this.state = {
       calendarData: [],
       currentMonth: date.getMonth()+1,
-      currentYear: date.getFullYear()
+      currentYear: date.getFullYear(),
+      maxMonth: new Date(date.setMonth(date.getMonth()+6)).getMonth()+1
     };
     this.fetchDataForMonth = this.fetchDataForMonth.bind(this);
     this.toggleSelectedDay = this.toggleSelectedDay.bind(this);
+    this.monthCanBeAdded = this.monthCanBeAdded.bind(this);
+    this.monthCanBeSubstracted = this.monthCanBeSubstracted.bind(this);
   }
 
   private focusListener: NavigationEventSubscription;
@@ -99,6 +103,21 @@ class ReservationCalendar extends Component<Props, CalendarState> {
         this.setState({calendarData: parkingEventsToCalendarEntries(releasesBySpot)});
       }
     }
+  }
+
+  monthCanBeAdded() {
+    if (this.state.currentMonth >= this.state.maxMonth) {
+      return false;
+    }
+    return true;
+  }
+
+  monthCanBeSubstracted() {
+    const currentDate = new Date();
+    if (this.state.currentMonth === currentDate.getMonth()+1) {
+      return false;
+    }
+    return true;
   }
 
   fetchDataForMonth(calendarDateObject: CalendarDateObject) {
@@ -174,6 +193,12 @@ class ReservationCalendar extends Component<Props, CalendarState> {
         onMonthChange={(calendarDateObject) => {
           this.fetchDataForMonth(calendarDateObject);
         }}
+        onPressArrowLeft={
+          (substractMonth) => this.monthCanBeSubstracted() === true ? substractMonth() : undefined
+        }
+        onPressArrowRight={
+          (addMonth) => this.monthCanBeAdded() === true ? addMonth() : undefined
+        }
         theme={{
           'textDayFontFamily': 'Exo2-bold',
           'textMonthFontFamily': 'Exo2-bold',

--- a/src/components/ReservationCalendar.tsx
+++ b/src/components/ReservationCalendar.tsx
@@ -31,13 +31,13 @@ class ReservationCalendar extends Component<Props, CalendarState> {
   constructor(props: Props) {
     super(props);
     const currentDate = new Date();
-    const initMaxDate = new Date();
-    const maxDate = new Date(initMaxDate.setMonth(initMaxDate.getMonth()+11));
+    const maxDate = new Date();
     // Adding (full) months to dates have different outcomes based on which is
     // the day parameter of the Date object. The day is set to middle of the
     // month to eliminate that. The date does not matter because we are only
     // interested about the month.
     maxDate.setDate(15);
+    maxDate.setMonth(currentDate.getMonth()+11);
     this.state = {
       calendarData: [],
       currentMonth: currentDate.getMonth()+1,


### PR DESCRIPTION
- Reservations and releases can be done (current month + 11 months) in to future
- When calendar initializes to the current month, user can't go to the previous month

There was some problems with the calendar component. The initial idea was to disable the arrow buttons when changing month is not possible but that did not work as documented.
This solution don't let user to change month, if he is trying to escape the month range. The buttons are still not disabled though.