### PR TITLE
Fix splash screen margin issue on iOS

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
     "orientation": "portrait",
     "icon": "./assets/images/app-icon/app-icon.png",
     "splash": {
-      "image": "./assets/images/parkdude-logo/drawable-xxhdpi/parkdude.png",
+      "image": "./assets/images/splash-screen/drawable-xxhdpi/splash-screen.png",
       "backgroundColor": "#ffffff",
       "resizeMode": "contain"
     },


### PR DESCRIPTION
iOS was using wrong image, which did not have margin. This should hopefully fix that.

Closes #33.