### PR TITLE
Bug fix - clear error text on new release modal

### DIFF
--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -109,11 +109,15 @@ class MainView extends Component<Props, State> {
       const dates = Object.keys(this.state.userSelectedDates);
       this.getAvailableParkingSpots(dates);
     }
-    this.setState({reservationModalVisible: !this.state.reservationModalVisible});
+    this.setState((prevState) => ({
+      reservationModalVisible: !prevState.reservationModalVisible
+    }));
   }
 
   toggleErrorModal() {
-    this.setState({errorModalVisible: !this.state.errorModalVisible});
+    this.setState((prevState) => ({
+      errorModalVisible: !prevState.errorModalVisible
+    }));
   }
 
   render() {

--- a/src/components/MyParkingsView.tsx
+++ b/src/components/MyParkingsView.tsx
@@ -174,18 +174,26 @@ class MyParkingsView extends Component<Props, State> {
   }
 
   toggleDeleteModal() {
-    this.setState({deleteModalVisible: !this.state.deleteModalVisible});
+    this.setState((prevState) => ({
+      deleteModalVisible: !prevState.deleteModalVisible
+    }));
   }
 
   toggleErrorModal() {
-    this.setState({errorModalVisible: !this.state.errorModalVisible, errorText: ''});
+    this.setState((prevState) => ({
+      deleteModalVisible: !prevState.errorModalVisible,
+      errorText: ''
+    }));
   }
 
   toggleNewReleaseModal(spot?: BasicParkingSpotData) {
     if (spot !== undefined) {
       this.setState({spotToBeReleased: spot});
     }
-    this.setState({newReleaseModalVisible: !this.state.newReleaseModalVisible});
+    this.setState((prevState) => ({
+      newReleaseModalVisible: !prevState.newReleaseModalVisible,
+      releaseModalErrorText: prevState.newReleaseModalVisible ? '' : prevState.releaseModalErrorText
+    }));
   }
 
   async delete() {

--- a/src/components/MyParkingsView.tsx
+++ b/src/components/MyParkingsView.tsx
@@ -181,7 +181,7 @@ class MyParkingsView extends Component<Props, State> {
 
   toggleErrorModal() {
     this.setState((prevState) => ({
-      deleteModalVisible: !prevState.errorModalVisible,
+      errorModalVisible: !prevState.errorModalVisible,
       errorText: ''
     }));
   }


### PR DESCRIPTION
Related to #38 

- Fixed bug where error text is never cleared from New release modal

Some code cleaning:
- Added prevState parameter to setState operations, which access this.state inside the setState function. (https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous) 